### PR TITLE
Add intl twig extension to get translates countries, languages and locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,23 @@
 composer require massive/web-twig-extensions ^1.0
 ```
 
-## Component
+## Extensions
+
+### 1. Component
 
 The [web component twig extension](docs/component.md) in connection with [web-js](https://github.com/massiveart/web-js)
 gives you simple and efficient way to handle your javascript components over twig.
 
 [More](docs/component.md)
 
-## Image
+### 2. Image
 
 The [web image twig extension](docs/image.md) gives you a simple and efficient way to handle your image over twig.
 
 [More](docs/image.md)
+
+### 3. Intl
+
+The [web intl twig extension](docs/intl.md) gives you a simple and efficient way to get country, languages and locales in a specific language.
+
+[More](docs/intl.md)

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,12 @@
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0",
         "symfony/property-access": "^2.8 || ^3.0 || ^4.0",
+        "symfony/intl": "^2.8 || ^3.0 || ^4.0",
         "friendsofphp/php-cs-fixer": "^2.11"
     },
     "suggest": {
-        "symfony/property-access": "The ImageTwigExtension requires the symfony/property-access service."
+        "symfony/property-access": "The ImageTwigExtension requires the symfony/property-access service.",
+        "symfony/intl": "The IntlTwigExtension requires the symfony/intl service."
     },
     "autoload": {
         "psr-4": {

--- a/docs/image.md
+++ b/docs/image.md
@@ -18,7 +18,7 @@ The twig extension need to be registered as [symfony service](http://symfony.com
         http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="app.web_image" class="Massive\Component\Web\ImageTwigExtension">
+        <service id="app.twig.web_image" class="Massive\Component\Web\ImageTwigExtension">
             <tag name="twig.extension" />
         </service>
     </services>

--- a/docs/intl.md
+++ b/docs/intl.md
@@ -1,0 +1,109 @@
+# Intl Twig Extension
+
+The intl twig extension gives you a simple and efficient way to get country, language or a locale in a specific locale.
+
+## Setup
+
+### Service Registration
+
+The twig extension need to be registered as [symfony service](http://symfony.com/doc/current/service_container.html).
+
+**xml**
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="app.twig.web_intl" class="Massive\Component\Web\IntlTwigExtension">
+            <tag name="twig.extension" />
+        </service>
+    </services>
+</container>
+```
+
+**yml**
+
+```yml
+services:
+    app.twig.web_intl:
+        class: Massive\Component\Web\IntlTwigExtension
+        tags:
+            - { name: twig.extension }
+```
+
+## Usage
+
+### Get country
+
+You can get a country in a specific language:
+
+```twig
+{{ intl_country('de') }}
+{{ intl_country('de', 'de') }}
+```
+
+Output:
+
+```html
+Germany
+Deutschland
+```
+
+### Get language
+
+You can get a language in a specfic language:
+
+```twig
+{{ intl_language('de') }}
+{{ intl_language('de', null, 'de') }}
+{{ intl_language('de', 'AT') }}
+{{ intl_language('de', 'AT', 'de') }}
+```
+
+Output:
+
+```html
+German
+Deutsch
+Austrian German
+Österreichisches Deutsch
+```
+
+### Get locale
+
+You can get a locale in a specfic language:
+
+```twig
+{{ intl_locale('de') }}
+{{ intl_locale('de', 'de') }}
+{{ intl_locale('de_AT') }}
+{{ intl_locale('de_AT' 'de') }}
+```
+
+Output:
+
+```html
+German
+Deutsch
+German (Austria)
+Deutsch (Österreich)
+```
+
+### Get icu locale
+
+Convert a de-at locale to a valid de_AT:
+
+```twig
+{{ 'de-at'|intl_icu_locale }}
+```
+
+Output:
+
+```html
+de_AT
+```
+

--- a/src/IntlTwigExtension.php
+++ b/src/IntlTwigExtension.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Massive\Component\Web;
+
+use Symfony\Component\Intl\Intl;
+
+/**
+ * This Twig Extension manages the image formats.
+ */
+class IntlTwigExtension extends \Twig_Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('intl_country', [$this, 'getCountry']),
+            new \Twig_SimpleFunction('intl_locale', [$this, 'getLocale']),
+            new \Twig_SimpleFunction('intl_language', [$this, 'getLanguage']),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('intl_icu_locale', [$this, 'getIcuLocale']),
+        ];
+    }
+
+    /**
+     * Get icu locale from sulu locale.
+     *
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function getIcuLocale($locale)
+    {
+        $parts = explode('-', $locale);
+        if (isset($parts[1])) {
+            $parts[1] = strtoupper($parts[1]);
+        }
+
+        return implode('_', $parts);
+    }
+
+    /**
+     * Get country.
+     *
+     * @param string $country
+     * @param string|null $displayLocale
+     *
+     * @return string
+     */
+    public function getCountry($country, $displayLocale = null)
+    {
+        return Intl::getRegionBundle()->getCountryName(strtoupper($country), $displayLocale);
+    }
+
+    /**
+     * Get language.
+     *
+     * @param string $language
+     * @param string|null $region
+     * @param string|null $displayLocale
+     *
+     * @return string
+     */
+    public function getLanguage($language, $region = null, $displayLocale = null)
+    {
+        return Intl::getLanguageBundle()->getLanguageName($language, $region, $displayLocale);
+    }
+
+    /**
+     * Get locale.
+     *
+     * @param string $locale
+     * @param string|null $displayLocale
+     *
+     * @return string
+     */
+    public function getLocale($locale, $displayLocale = null)
+    {
+        return Intl::getLocaleBundle()->getLocaleName($locale, $displayLocale);
+    }
+}

--- a/tests/IntlTwigExtensionTest.php
+++ b/tests/IntlTwigExtensionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Massive\Component\Web\IntlTwigExtension;
+use PHPUnit\Framework\TestCase;
+
+class IntlTwigExtensionTest extends TestCase
+{
+    /**
+     * @var IntlTwigExtension
+     */
+    private $intlTwigExtension;
+
+    public function setup()
+    {
+        $this->intlTwigExtension = new IntlTwigExtension();
+    }
+
+    public function testLocalize()
+    {
+        $this->assertEquals(
+            'de_AT',
+            $this->intlTwigExtension->getIcuLocale('de-at')
+        );
+
+        $this->assertEquals(
+            'de',
+            $this->intlTwigExtension->getIcuLocale('de')
+        );
+    }
+
+    public function testCountry()
+    {
+        $this->assertEquals(
+            'Germany',
+            $this->intlTwigExtension->getCountry('de', 'en')
+        );
+
+        $this->assertEquals(
+            'Deutschland',
+            $this->intlTwigExtension->getCountry('de', 'de')
+        );
+    }
+
+    public function testLanguage()
+    {
+        $this->assertEquals(
+            'German',
+            $this->intlTwigExtension->getLanguage('de', null, 'en')
+        );
+
+        $this->assertEquals(
+            'Deutsch',
+            $this->intlTwigExtension->getLanguage('de', null, 'de')
+        );
+
+        $this->assertEquals(
+            'Austrian German',
+            $this->intlTwigExtension->getLanguage('de', 'AT', 'en')
+        );
+
+        $this->assertEquals(
+            'Österreichisches Deutsch',
+            $this->intlTwigExtension->getLanguage('de', 'AT', 'de')
+        );
+    }
+
+    public function testLocale()
+    {
+        $this->assertEquals(
+            'Deutsch',
+            $this->intlTwigExtension->getLocale('de', 'de')
+        );
+
+        $this->assertEquals(
+            'German',
+            $this->intlTwigExtension->getLocale('de', 'en')
+        );
+
+        $this->assertEquals(
+            'Deutsch (Österreich)',
+            $this->intlTwigExtension->getLocale('de_AT', 'de')
+        );
+
+        $this->assertEquals(
+            'German (Austria)',
+            $this->intlTwigExtension->getLocale('de_AT', 'en')
+        );
+    }
+}


### PR DESCRIPTION
# Intl Twig Extension

The intl twig extension gives you a simple and efficient way to get country, language or a locale in a specific locale.

## Usage

When no displayLocale is given it uses the configure Intl Default locale in the examples this is EN.

### Get country

You can get a country in a specific language:

```twig
{{ intl_country('de') }}
{{ intl_country('de', 'de') }}
```

Output:

```html
Germany
Deutschland
```

### Get language

You can get a language in a specfic language:

```twig
{{ intl_language('de') }}
{{ intl_language('de', null, 'de') }}
{{ intl_language('de', 'AT') }}
{{ intl_language('de', 'AT', 'de') }}
```

Output:

```html
German
Deutsch
Austrian German
Österreichisches Deutsch
```

### Get locale

You can get a locale in a specfic language:

```twig
{{ intl_locale('de') }}
{{ intl_locale('de', 'de') }}
{{ intl_locale('de_AT') }}
{{ intl_locale('de_AT' 'de') }}
```

Output:

```html
German
Deutsch
German (Austria)
Deutsch (Österreich)
```

### Get icu locale

Convert a de-at locale to a valid de_AT:

```twig
{{ 'de-at'|intl_icu_locale }}
```

Output:

```html
de_AT
```
