### PR TITLE
Allow to give source format as string

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -78,7 +78,28 @@ This could be:
 }) }}
 ```
 
-##### 3. Picture tag
+##### 3. Simple Picture Tag
+
+```twig
+<picture>
+    <source media="(max-width: 1024px)"
+            srcset="/uploads/media/sulu-170x170/01/image.jpg?v=1-0">
+    <source media="(max-width: 650px)"
+            srcset="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">
+    <img alt="Title"
+         title="Description"
+         src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0">
+</picture>
+```
+
+```twig
+{{ get_image(headerImage, 'sulu-400x400', {
+    '(max-width: 1024px)': 'sulu-170x170',
+    '(max-width: 650px)': 'sulu-100x100',
+}) }}
+```
+
+##### 4. Complex Picture tag
 
 ```twig
 <picture>

--- a/src/ImageTwigExtension.php
+++ b/src/ImageTwigExtension.php
@@ -66,6 +66,11 @@ class ImageTwigExtension extends \Twig_Extension
 
         $sourceTags = '';
         foreach ($sources as $media => $sourceAttributes) {
+            if (is_string($sourceAttributes)) {
+                $sourceAttributes = [
+                    'srcset' => $sourceAttributes,
+                ];
+            }
             // Get the source tag with all given attributes.
             $sourceTags .= $this->createTag('source', array_merge(['media' => $media], $sourceAttributes), $thumbnails);
         }

--- a/tests/ImageTwigExtensionTest.php
+++ b/tests/ImageTwigExtensionTest.php
@@ -74,6 +74,29 @@ class ImageTwigExtensionTest extends TestCase
         $this->assertEquals(
             '<picture>' .
             '<source media="(max-width: 1024px)"' .
+                ' srcset="/uploads/media/sulu-170x170/01/image.jpg?v=1-0">' .
+            '<source media="(max-width: 650px)"' .
+                ' srcset="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">' .
+            '<img alt="Title"' .
+                ' title="Description"' .
+                ' src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0">' .
+            '</picture>',
+            $this->imageTwigExtension->getImage(
+                $this->image,
+                'sulu-400x400',
+                [
+                    '(max-width: 1024px)' => 'sulu-170x170',
+                    '(max-width: 650px)' => 'sulu-100x100',
+                ]
+            )
+        );
+    }
+
+    public function testComplexPictureTag()
+    {
+        $this->assertEquals(
+            '<picture>' .
+            '<source media="(max-width: 1024px)"' .
                 ' srcset="/uploads/media/sulu-400x400/01/image.jpg?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.jpg?v=1-0 800w, /uploads/media/sulu-100x100/01/image.jpg?v=1-0 460w"' .
                 ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw">' .
             '<source media="(max-width: 650px)"' .


### PR DESCRIPTION
Instead of writting:

```twig
{{ get_image(headerImage, '960x', {
    '(max-width: 991px)': {
        srcset: '720x',
    },
    '(max-width: 577px)': {
        srcset: '580x',
    },
}) }}
```

You can now:

```twig
{{ get_image(headerImage, '960x', {
    '(max-width: 991px)': '720x',
    '(max-width: 577px)': '580x',
}) }}
```

Its the same behaviour as for the main image format: https://github.com/massiveart/web-twig/blob/f975ddd10a5a6f08a3d5684b56e9dde6a4203471/src/ImageTwigExtension.php#L48-L52