### PR TITLE
Added count twig extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ The [web image twig extension](docs/image.md) gives you a simple and efficient w
 The [web intl twig extension](docs/intl.md) gives you a simple and efficient way to get country, languages and locales in a specific language.
 
 [More](docs/intl.md)
+
+### 4. count
+
+The [web count twig extension](docs/count.md) gives you a simple and efficient way to have a global counter in your twig template.
+
+[More](docs/count.md)

--- a/docs/count.md
+++ b/docs/count.md
@@ -59,3 +59,9 @@ Output:
 2
 1
 ```
+
+A more real use case would be to check for odd or even:
+
+```twig
+<div class="section section--{% if counter('section') is odd %}black{% endif %}">
+```

--- a/docs/count.md
+++ b/docs/count.md
@@ -1,0 +1,61 @@
+# Count Twig Extension
+
+The count twig extension gives you a simple and efficient way to have a global counter in your twig template.
+
+## Setup
+
+### Service Registration
+
+The twig extension need to be registered as [symfony service](http://symfony.com/doc/current/service_container.html).
+
+**xml**
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="app.twig.web_count" class="Massive\Component\Web\CountTwigExtension">
+            <tag name="twig.extension" />
+        </service>
+    </services>
+</container>
+```
+
+**yml**
+
+```yml
+services:
+    app.twig.web_count:
+        class: Massive\Component\Web\CountTwigExtension
+        tags:
+            - { name: twig.extension }
+```
+
+## Usage
+
+### Counter
+
+You can increase and get the current counter with:
+
+```twig
+{{ counter('example') }}
+{{ counter('example') }}
+{{ counter('test') }}
+{{ counter('test') }}
+{% do reset_counter('example') %}
+{{ counter('example') }}
+```
+
+Output:
+
+```html
+1
+2
+1
+2
+1
+```

--- a/docs/count.md
+++ b/docs/count.md
@@ -63,5 +63,5 @@ Output:
 A more real use case would be to check for odd or even:
 
 ```twig
-<div class="section section--{% if counter('section') is odd %}black{% endif %}">
+<div class="section{% if counter('section') is odd %} section--black{% endif %}">
 ```

--- a/src/CountTwigExtension.php
+++ b/src/CountTwigExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Massive\Component\Web;
+
+class CountTwigExtension extends \Twig_Extension
+{
+    /**
+     * @var array
+     */
+    private $counters = [];
+
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('counter', [$this, 'increaseCounter']),
+            new \Twig_SimpleFunction('reset_counter', [$this, 'resetCounter']),
+            new \Twig_SimpleFunction('get_counter', [$this, 'getCounter']),
+        ];
+    }
+
+    public function increaseCounter($group)
+    {
+        if (!isset($this->counters[$group])) {
+            $this->counters[$group] = 0;
+        }
+
+        return ++$this->counters[$group];
+    }
+
+    public function resetCounter($group)
+    {
+        $this->counters[$group] = 0;
+    }
+
+    public function getCounter($group)
+    {
+        return isset($this->counters[$group]) ? $this->counters[$group] : 0;
+    }
+}

--- a/tests/CountTwigExtensionTest.php
+++ b/tests/CountTwigExtensionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Massive\Component\Web\CountTwigExtension;
+use PHPUnit\Framework\TestCase;
+
+class CountTwigExtensionTest extends TestCase
+{
+    /**
+     * @varCountTwigExtension
+     */
+    private $countTwigExtension;
+
+    public function setup()
+    {
+        $this->countTwigExtension = new CountTwigExtension();
+    }
+
+    public function testCount()
+    {
+        $this->assertSame(1, $this->countTwigExtension->increaseCounter('test'));
+        $this->assertSame(2, $this->countTwigExtension->increaseCounter('test'));
+        $this->assertSame(1, $this->countTwigExtension->increaseCounter('example'));
+        $this->assertSame(2, $this->countTwigExtension->increaseCounter('example'));
+        $this->assertSame(2, $this->countTwigExtension->getCounter('example'));
+        $this->countTwigExtension->resetCounter('test');
+        $this->assertSame(3, $this->countTwigExtension->increaseCounter('example'));
+        $this->assertSame(1, $this->countTwigExtension->increaseCounter('test'));
+        $this->assertSame(1, $this->countTwigExtension->getCounter('test'));
+        $this->countTwigExtension->resetCounter('example');
+        $this->assertSame(1, $this->countTwigExtension->increaseCounter('example'));
+    }
+}


### PR DESCRIPTION
The count twig extensions can be used for a global counter variable:

```twig
<section class="section{% if counter('section') is odd %} section--odd{% endif %}">
     ...
<section>
```