### PR TITLE
Added get_lazy_image and has_lazy_image function

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -164,3 +164,11 @@ The placeholder svg should look like this:
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"/>
 ```
+
+With the `has_lazy_image()` twig function you could check if the current rendered code includes one ore more lazy images.
+
+```twig
+{% if has_lazy_image() %}
+    <script src="lazy.js"></script>
+{% endif %}
+```

--- a/docs/image.md
+++ b/docs/image.md
@@ -19,6 +19,7 @@ The twig extension need to be registered as [symfony service](http://symfony.com
 
     <services>
         <service id="app.twig.web_image" class="Massive\Component\Web\ImageTwigExtension">
+            <argument>/images/placeholders</argument>
             <tag name="twig.extension" />
         </service>
     </services>
@@ -31,6 +32,8 @@ The twig extension need to be registered as [symfony service](http://symfony.com
 services:
     app.web_image:
         class: Massive\Component\Web\ImageTwigExtension
+        arguments:
+            - '/images/placeholders'
         tags:
             - { name: twig.extension }
 ```
@@ -135,4 +138,29 @@ This could be:
         }
     }
 ) }}
+```
+
+##### 5. Lazy images
+
+The `get_lazy_image` twig function accepts the same parameters as the `get_image` function.
+It will render the img attributes `src` and `srcset` as `data-src` and `data-srcset`.
+Values of `src` and `srcset` are set to a placeholder svg image of the configured `placeholderPath`
+
+Use for example [lazysizes](https://github.com/aFarkas/lazysizes) JS Library to load the images when they are visible.
+
+```twig
+<img alt="Test" title="Test" data-src="/images/placeholders/sulu-100x100.svg" src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">
+```
+
+This could be:
+
+```twig
+{{ get_lazy_image(image, 'sulu-100x100') }}
+```
+
+The placeholder svg should look like this:
+
+```svg
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"/>
 ```

--- a/src/ImageTwigExtension.php
+++ b/src/ImageTwigExtension.php
@@ -17,10 +17,10 @@ class ImageTwigExtension extends \Twig_Extension
     /**
      * @var bool
      */
-    protected $hasLazyImages = false;
+    protected $hasLazyImage = false;
 
     /**
-     * @var array
+     * @var string[]
      */
     private $placeholders = null;
 
@@ -39,7 +39,7 @@ class ImageTwigExtension extends \Twig_Extension
         return [
             new \Twig_SimpleFunction('get_image', [$this, 'getImage'], ['is_safe' => ['html']]),
             new \Twig_SimpleFunction('get_lazy_image', [$this, 'getLazyImage'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('has_lazy_images', [$this, 'hasLazyImages']),
+            new \Twig_SimpleFunction('has_lazy_image', [$this, 'hasLazyImage']),
         ];
     }
 
@@ -66,7 +66,7 @@ class ImageTwigExtension extends \Twig_Extension
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $thumbnails = $propertyAccessor->getValue($media, 'thumbnails');
-        $this->hasLazyImages = true;
+        $this->hasLazyImage = true;
 
         return $this->createImage($media, $attributes, $sources, $this->getLazyThumbnails($thumbnails));
     }
@@ -76,9 +76,9 @@ class ImageTwigExtension extends \Twig_Extension
      *
      * @return bool
      */
-    public function hasLazyImages()
+    public function hasLazyImage()
     {
-        return $this->hasLazyImages;
+        return $this->hasLazyImage;
     }
 
     /**

--- a/src/ImageTwigExtension.php
+++ b/src/ImageTwigExtension.php
@@ -10,13 +10,89 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 class ImageTwigExtension extends \Twig_Extension
 {
     /**
+     * @var string|null
+     */
+    protected $placeholderPath;
+
+    /**
+     * @var bool
+     */
+    protected $hasLazyImages = false;
+
+    /**
+     * @var array
+     */
+    private $placeholders = null;
+
+    public function __construct($placeholderPath = null)
+    {
+        if (null !== $placeholderPath) {
+            $this->placeholderPath = rtrim($placeholderPath, '/') . '/';
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return [
             new \Twig_SimpleFunction('get_image', [$this, 'getImage'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('get_lazy_image', [$this, 'getLazyImage'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('has_lazy_images', [$this, 'hasLazyImages']),
         ];
+    }
+
+    /**
+     * Get an image or picture tag with given attributes for lazy loading.
+     *
+     * @param mixed $media
+     * @param string[]|string $attributes
+     * @param string[] $sources
+     *
+     * @return string
+     */
+    public function getLazyImage($media, $attributes = [], array $sources = [])
+    {
+        if (null === $this->placeholderPath) {
+            throw new \InvalidArgumentException(
+                'You need to define placeholderPaths constructor argument to use the get_lazy_image function'
+            );
+        }
+
+        if (is_array($media)) {
+            $media = (object) $media;
+        }
+
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $thumbnails = $propertyAccessor->getValue($media, 'thumbnails');
+        $this->hasLazyImages = true;
+
+        return $this->createImage($media, $attributes, $sources, $this->getLazyThumbnails($thumbnails));
+    }
+
+    /**
+     * Get lazy image was called once or more times.
+     *
+     * @return bool
+     */
+    public function hasLazyImages()
+    {
+        return $this->hasLazyImages;
+    }
+
+    /**
+     * Get an image or picture tag with given attributes.
+     *
+     * @param mixed $media
+     * @param string[]|string $attributes
+     * @param string[] $sources
+     *
+     * @return string
+     */
+    public function getImage($media, $attributes = [], array $sources = [])
+    {
+        return $this->createImage($media, $attributes, $sources);
     }
 
     /**
@@ -25,11 +101,16 @@ class ImageTwigExtension extends \Twig_Extension
      * @param mixed $media
      * @param array|string $attributes
      * @param array $sources
+     * @param null|string[] $lazyThumbnails
      *
      * @return string
      */
-    public function getImage($media, $attributes = [], $sources = [])
-    {
+    private function createImage(
+        $media,
+        $attributes = [],
+        array $sources = [],
+        $lazyThumbnails = null
+    ) {
         // Return an empty string if no one of the needed parameters is set.
         if (empty($media) || empty($attributes)) {
             return '';
@@ -51,6 +132,10 @@ class ImageTwigExtension extends \Twig_Extension
             ];
         }
 
+        if ($lazyThumbnails) {
+            $attributes['class'] = trim((isset($attributes['class']) ? $attributes['class'] : '') . ' lazyload');
+        }
+
         // Get title from object to use as alt attribute.
         $alt = $propertyAccessor->getValue($media, 'title');
 
@@ -58,7 +143,12 @@ class ImageTwigExtension extends \Twig_Extension
         $title = $propertyAccessor->getValue($media, 'description') ?: $alt;
 
         // Get the image tag with all given attributes.
-        $imgTag = $this->createTag('img', array_merge(['alt' => $alt, 'title' => $title], $attributes), $thumbnails);
+        $imgTag = $this->createTag(
+            'img',
+            array_merge(['alt' => $alt, 'title' => $title], $attributes),
+            $thumbnails,
+            $lazyThumbnails
+        );
 
         if (empty($sources)) {
             return $imgTag;
@@ -72,7 +162,12 @@ class ImageTwigExtension extends \Twig_Extension
                 ];
             }
             // Get the source tag with all given attributes.
-            $sourceTags .= $this->createTag('source', array_merge(['media' => $media], $sourceAttributes), $thumbnails);
+            $sourceTags .= $this->createTag(
+                'source',
+                array_merge(['media' => $media], $sourceAttributes),
+                $thumbnails,
+                $lazyThumbnails
+            );
         }
 
         // Returns the picture tag with all sources and the fallback image tag.
@@ -83,20 +178,35 @@ class ImageTwigExtension extends \Twig_Extension
      * Create html tag.
      *
      * @param string $tag
-     * @param array $attributes
-     * @param array $thumbnails
+     * @param string[] $attributes
+     * @param string[] $thumbnails
+     * @param null|string[] $lazyThumbnails
      *
      * @return string
      */
-    private function createTag($tag, $attributes, $thumbnails)
+    private function createTag($tag, $attributes, $thumbnails, $lazyThumbnails = null)
     {
         $output = '';
 
         foreach ($attributes as $key => $value) {
             if ('src' === $key) {
+                if ($lazyThumbnails) {
+                    $output .= sprintf(' %s="%s"', $key, $lazyThumbnails[$value]);
+                    $key = 'data-src';
+                }
+
                 // Set the thumbnail instead of image itself.
                 $value = $thumbnails[$value];
             } elseif ('srcset' === $key) {
+                if ($lazyThumbnails) {
+                    $output .= sprintf(
+                        ' %s="%s"',
+                        $key,
+                        htmlentities($this->srcsetThumbnailReplace($value, $lazyThumbnails))
+                    );
+                    $key = 'data-srcset';
+                }
+
                 // Replace thumbnail format in srcset.
                 $value = $this->srcsetThumbnailReplace($value, $thumbnails);
             }
@@ -111,7 +221,7 @@ class ImageTwigExtension extends \Twig_Extension
      * Replace the given image format with an thumbnail.
      *
      * @param string $value
-     * @param array $thumbnails
+     * @param string[] $thumbnails
      *
      * @return string
      */
@@ -137,5 +247,30 @@ class ImageTwigExtension extends \Twig_Extension
         }
 
         return implode(', ', $newSrcSets);
+    }
+
+    /**
+     * Get lazy thumbnails.
+     *
+     * @param string[] $thumbnails
+     *
+     * @return string[]|null
+     */
+    private function getLazyThumbnails($thumbnails)
+    {
+        if (empty($thumbnails)) {
+            return null;
+        }
+
+        if (null === $this->placeholders) {
+            $placeholders = [];
+            foreach (array_keys($thumbnails) as $key) {
+                $placeholders[$key] = $this->placeholderPath . $key . '.svg';
+            }
+
+            $this->placeholders = $placeholders;
+        }
+
+        return $this->placeholders;
     }
 }

--- a/tests/ImageTwigExtensionTest.php
+++ b/tests/ImageTwigExtensionTest.php
@@ -17,7 +17,7 @@ class ImageTwigExtensionTest extends TestCase
 
     public function setup()
     {
-        $this->imageTwigExtension = new ImageTwigExtension();
+        $this->imageTwigExtension = new ImageTwigExtension('/lazy');
         $this->image = [
             'title' => 'Title',
             'description' => 'Description',
@@ -108,6 +108,105 @@ class ImageTwigExtensionTest extends TestCase
                 ' class="image-class">' .
             '</picture>',
             $this->imageTwigExtension->getImage(
+                $this->image,
+                [
+                    'src' => 'sulu-400x400',
+                    'class' => 'image-class',
+                ],
+                [
+                    '(max-width: 1024px)' => [
+                        'srcset' => 'sulu-400x400 1024w, sulu-170x170 800w, sulu-100x100 460w',
+                        'sizes' => '(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw',
+                    ],
+                    '(max-width: 650px)' => [
+                        'srcset' => 'sulu-400x400 1024w, sulu-170x170 800w, sulu-100x100 460w',
+                        'sizes' => '(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw',
+                    ],
+                ]
+            )
+        );
+    }
+
+    public function testLazyImageTag()
+    {
+        $this->assertEquals(
+            '<img alt="Title" title="Description" src="/lazy/sulu-100x100.svg" data-src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0" class="lazyload">',
+            $this->imageTwigExtension->getLazyImage($this->image, 'sulu-100x100')
+        );
+    }
+
+    public function testLazyComplexImageTag()
+    {
+        $this->assertEquals(
+            '<img alt="Logo"' .
+            ' title="Description"' .
+            ' src="/lazy/sulu-400x400.svg"' .
+            ' data-src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0"' .
+            ' srcset="/lazy/sulu-400x400.svg 1024w, /lazy/sulu-170x170.svg 800w, /lazy/sulu-100x100.svg 460w"' .
+            ' data-srcset="/uploads/media/sulu-400x400/01/image.jpg?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.jpg?v=1-0 800w, /uploads/media/sulu-100x100/01/image.jpg?v=1-0 460w"' .
+            ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw"' .
+            ' id="image-id"' .
+            ' class="image-class lazyload">',
+            $this->imageTwigExtension->getLazyImage(
+                $this->image,
+                [
+                    'src' => 'sulu-400x400',
+                    'srcset' => 'sulu-400x400 1024w, sulu-170x170 800w, sulu-100x100 460w',
+                    'sizes' => '(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw',
+                    'id' => 'image-id',
+                    'class' => 'image-class',
+                    'alt' => 'Logo',
+                ]
+            )
+        );
+    }
+
+    public function testLazyPictureTag()
+    {
+        $this->assertEquals(
+            '<picture>' .
+            '<source media="(max-width: 1024px)"' .
+            ' srcset="/lazy/sulu-170x170.svg"' .
+            ' data-srcset="/uploads/media/sulu-170x170/01/image.jpg?v=1-0">' .
+            '<source media="(max-width: 650px)"' .
+            ' srcset="/lazy/sulu-100x100.svg"' .
+            ' data-srcset="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">' .
+            '<img alt="Title"' .
+            ' title="Description"' .
+            ' src="/lazy/sulu-400x400.svg"' .
+            ' data-src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0"' .
+            ' class="lazyload">' .
+            '</picture>',
+            $this->imageTwigExtension->getLazyImage(
+                $this->image,
+                'sulu-400x400',
+                [
+                    '(max-width: 1024px)' => 'sulu-170x170',
+                    '(max-width: 650px)' => 'sulu-100x100',
+                ]
+            )
+        );
+    }
+
+    public function testLazyComplexPictureTag()
+    {
+        $this->assertEquals(
+            '<picture>' .
+            '<source media="(max-width: 1024px)"' .
+            ' srcset="/lazy/sulu-400x400.svg 1024w, /lazy/sulu-170x170.svg 800w, /lazy/sulu-100x100.svg 460w"' .
+            ' data-srcset="/uploads/media/sulu-400x400/01/image.jpg?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.jpg?v=1-0 800w, /uploads/media/sulu-100x100/01/image.jpg?v=1-0 460w"' .
+            ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw">' .
+            '<source media="(max-width: 650px)"' .
+            ' srcset="/lazy/sulu-400x400.svg 1024w, /lazy/sulu-170x170.svg 800w, /lazy/sulu-100x100.svg 460w"' .
+            ' data-srcset="/uploads/media/sulu-400x400/01/image.jpg?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.jpg?v=1-0 800w, /uploads/media/sulu-100x100/01/image.jpg?v=1-0 460w"' .
+            ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw">' .
+            '<img alt="Title"' .
+            ' title="Description"' .
+            ' src="/lazy/sulu-400x400.svg"' .
+            ' data-src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0"' .
+            ' class="image-class lazyload">' .
+            '</picture>',
+            $this->imageTwigExtension->getLazyImage(
                 $this->image,
                 [
                     'src' => 'sulu-400x400',

--- a/tests/ImageTwigExtensionTest.php
+++ b/tests/ImageTwigExtensionTest.php
@@ -225,4 +225,16 @@ class ImageTwigExtensionTest extends TestCase
             )
         );
     }
+
+    public function testHasLazyImage()
+    {
+        $this->assertFalse($this->imageTwigExtension->hasLazyImage());
+        $this->imageTwigExtension->getImage($this->image, 'sulu-400x400');
+        $this->assertFalse($this->imageTwigExtension->hasLazyImage());
+        $this->imageTwigExtension->getLazyImage($this->image, 'sulu-400x400');
+        $this->assertTrue($this->imageTwigExtension->hasLazyImage());
+        $this->imageTwigExtension->getLazyImage($this->image, 'sulu-400x400');
+        $this->imageTwigExtension->getImage($this->image, 'sulu-400x400');
+        $this->assertTrue($this->imageTwigExtension->hasLazyImage());
+    }
 }


### PR DESCRIPTION
Example usage:

```xml
<service id="Massive\Component\Web\ImageTwigExtension">
    <argument>/images/placeholders</argument>

    <tag name="twig.extension"/>
</service>
```

```twig
{{ get_lazy_image(image, '600x400') }}
```

Output:

```html
<img alt="Test" title="Test" data-src="/images/placeholders/600x400.svg" src="/uploads/media/sulu-600x400/01/image.jpg?v=1-0">
```

It accept the same parameters as `get_image` function instead of render directly the `src` and `srcset` attributes it render to image with `data-src` and `data-srcset` and use the placeholder svg image as src or srcset. 

fixes #11