### PR TITLE
Added intl_countries, intl_languages, intl_locales twig extensions

### DIFF
--- a/docs/intl.md
+++ b/docs/intl.md
@@ -53,6 +53,8 @@ Germany
 Deutschland
 ```
 
+You can also get a list of countries by using `intl_countries('de')`.
+
 ### Get language
 
 You can get a language in a specfic language:
@@ -73,6 +75,8 @@ Austrian German
 Österreichisches Deutsch
 ```
 
+You can also get a list of languages by using `intl_languages('de')`.
+
 ### Get locale
 
 You can get a locale in a specfic language:
@@ -92,6 +96,8 @@ Deutsch
 German (Austria)
 Deutsch (Österreich)
 ```
+
+You can also get a list of locales by using `intl_locales('de')`.
 
 ### Get icu locale
 

--- a/src/IntlTwigExtension.php
+++ b/src/IntlTwigExtension.php
@@ -15,8 +15,11 @@ class IntlTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
+            new \Twig_SimpleFunction('intl_countries', [$this, 'getCountries']),
             new \Twig_SimpleFunction('intl_country', [$this, 'getCountry']),
+            new \Twig_SimpleFunction('intl_locales', [$this, 'getLocales']),
             new \Twig_SimpleFunction('intl_locale', [$this, 'getLocale']),
+            new \Twig_SimpleFunction('intl_languages', [$this, 'getLanguages']),
             new \Twig_SimpleFunction('intl_language', [$this, 'getLanguage']),
         ];
     }
@@ -49,6 +52,18 @@ class IntlTwigExtension extends \Twig_Extension
     }
 
     /**
+     * Get countries.
+     *
+     * @param string|null $displayLocale
+     *
+     * @return string
+     */
+    public function getCountries($displayLocale = null)
+    {
+        return Intl::getRegionBundle()->getCountryNames($displayLocale);
+    }
+
+    /**
      * Get country.
      *
      * @param string $country
@@ -59,6 +74,18 @@ class IntlTwigExtension extends \Twig_Extension
     public function getCountry($country, $displayLocale = null)
     {
         return Intl::getRegionBundle()->getCountryName(strtoupper($country), $displayLocale);
+    }
+
+    /**
+     * Get languages.
+     *
+     * @param string|null $displayLocale
+     *
+     * @return string
+     */
+    public function getLanguages($displayLocale = null)
+    {
+        return Intl::getLanguageBundle()->getLanguageNames($displayLocale);
     }
 
     /**
@@ -73,6 +100,18 @@ class IntlTwigExtension extends \Twig_Extension
     public function getLanguage($language, $region = null, $displayLocale = null)
     {
         return Intl::getLanguageBundle()->getLanguageName($language, $region, $displayLocale);
+    }
+
+    /**
+     * Get locales.
+     *
+     * @param string|null $displayLocale
+     *
+     * @return string
+     */
+    public function getLocales($displayLocale = null)
+    {
+        return Intl::getLocaleBundle()->getLocaleNames($displayLocale);
     }
 
     /**

--- a/tests/IntlTwigExtensionTest.php
+++ b/tests/IntlTwigExtensionTest.php
@@ -41,6 +41,19 @@ class IntlTwigExtensionTest extends TestCase
         );
     }
 
+    public function testCountries()
+    {
+        $this->assertContains(
+            'Germany',
+            $this->intlTwigExtension->getCountries('en')
+        );
+
+        $this->assertContains(
+            'Deutschland',
+            $this->intlTwigExtension->getCountries('de')
+        );
+    }
+
     public function testLanguage()
     {
         $this->assertEquals(
@@ -64,6 +77,29 @@ class IntlTwigExtensionTest extends TestCase
         );
     }
 
+    public function testLanguages()
+    {
+        $this->assertContains(
+            'German',
+            $this->intlTwigExtension->getLanguages('en')
+        );
+
+        $this->assertContains(
+            'Austrian German',
+            $this->intlTwigExtension->getLanguages('en')
+        );
+
+        $this->assertContains(
+            'Deutsch',
+            $this->intlTwigExtension->getLanguages('de')
+        );
+
+        $this->assertContains(
+            'Österreichisches Deutsch',
+            $this->intlTwigExtension->getLanguages('de')
+        );
+    }
+
     public function testLocale()
     {
         $this->assertEquals(
@@ -84,6 +120,29 @@ class IntlTwigExtensionTest extends TestCase
         $this->assertEquals(
             'German (Austria)',
             $this->intlTwigExtension->getLocale('de_AT', 'en')
+        );
+    }
+
+    public function testLocales()
+    {
+        $this->assertContains(
+            'Deutsch',
+            $this->intlTwigExtension->getLocales('de')
+        );
+
+        $this->assertContains(
+            'German',
+            $this->intlTwigExtension->getLocales('en')
+        );
+
+        $this->assertContains(
+            'Deutsch (Österreich)',
+            $this->intlTwigExtension->getLocales('de')
+        );
+
+        $this->assertContains(
+            'German (Austria)',
+            $this->intlTwigExtension->getLocales('en')
         );
     }
 }


### PR DESCRIPTION
```twig
{% for country in intl_countries() %}
    {{ country }}
{% endfor %}
```

```twig
{% for language in intl_languages() %}
    {{ language }}
{% endfor %}
```

```twig
{% for locale in intl_locales() %}
    {{ locale }}
{% endfor %}
```

fixes #8 